### PR TITLE
Update README.md with correct clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Our repository is organized into key sections:
 
     ```bash
     # Clone the repository
-    git clone https://github.com/your-org/DataCents.git
-    cd DataCents
+    git clone https://github.com/MIT-Emerging-Talent/ET6-CDSP-group-15-repo.git
+    cd ET6-CDSP-group-15-repo
 
     # Create environment
     conda env create -f environment.yml


### PR DESCRIPTION
---
name: Update README clone URL
about: Simple PR to correct the clone command in the README file.
---

## Description

This pull request updates the clone URL in the `README.md` file, replacing the placeholder link with the actual repository URL:  
`https://github.com/MIT-Emerging-Talent/ET6-CDSP-group-15-repo.git`  
This ensures contributors can easily clone the repository without manual edits. No other changes were made.

## Checklist

- [x] README reflects the correct clone URL  
- [x] Markdown formatting looks correct on preview  
- [x] Spelling and grammar checked  
- [x] PR has a clear and descriptive title  
- [x] PR contributes only one focused change  
- [ ] Assigned to appropriate reviewers (if applicable)  
- [x] Labeled appropriately (e.g., `documentation`, `quick fix`)  
